### PR TITLE
Managed Instance General Dashboard Icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "commands": [],
     "views": {},
     "menus": {},
+    "icon": {
+      "light": "./images/ManagedInstanceLogo.png",
+      "dark": "./images/ManagedInstanceLogo.png"
+    },
     "dashboard.tabs": [
       {
         "id": "Managed-Instance",


### PR DESCRIPTION
I replaced the default extension icon with the MI icon:

![image](https://user-images.githubusercontent.com/28262823/177280257-dbe6caaa-c8e5-464f-9aef-d86ad5335743.png)

Keep in mind that these changes are not tested because I did not manage to reference my fork from ADS. I figured out how extension icons work from other extensions like: https://github.com/microsoft/azuredatastudio/blob/main/extensions/sql-migration/package.json.

