### PR TITLE
SQL MI ADS extension support for Next-Gen GP

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
             {
               "name": "Properties",
               "gridItemConfig": {
-                "sizex": 1,
+                "sizex": 2,
                 "sizey": 1
               },
               "widget": {
@@ -230,7 +230,7 @@
               }
             },
             {
-              "name": "Azure Premium Disk storage",
+              "name": "Azure Remote storage",
               "gridItemConfig": {
                 "sizex": 1,
                 "sizey": 1
@@ -242,7 +242,7 @@
 			{
 				"name": "Resource usage",
 				"gridItemConfig": {
-				  "sizex": 3,
+				  "sizex": 4,
 				  "sizey": 1
 				},
 				"widget": {

--- a/src/sql/properties.sql
+++ b/src/sql/properties.sql
@@ -3,27 +3,33 @@ select
     [Cores] = virtual_core_count, 
     [Memory] = CASE 
     WHEN hardware_generation = 'Gen4' THEN CONCAT(7 * virtual_core_count, ' GB')
+    WHEN hardware_generation = 'Gen5' THEN CONCAT(5.1 * virtual_core_count, ' GB')
+    WHEN hardware_generation = 'Gen6' THEN CONCAT(5.1 * virtual_core_count, ' GB')
+    WHEN hardware_generation = 'Gen7' THEN CONCAT(5.1 * virtual_core_count, ' GB')
+    WHEN hardware_generation = 'Gen8IM' THEN CONCAT(LEAST(7 * virtual_core_count, 560), ' GB')
+    WHEN hardware_generation = 'Gen8IH' THEN CONCAT(LEAST(13.6 * virtual_core_count, 870.4), ' GB')
     ELSE CONCAT(5.1 * virtual_core_count, ' GB')
     END,
     [Max storage] = CONCAT(max_storage_gb , ' GB'),
     [Service tier] = service_tier,
+    [Next-Gen General Purpose] = mf.[Next-Gen General Purpose],
     [Hardware generation] = hardware_generation, 
-	[Log write rate(max)] = 
+    [Log write rate(max)] =
     CASE 
-    WHEN service_tier = 'GeneralPurpose' AND virtual_core_count >= 8 THEN CONCAT(22, ' MB/s')
-    WHEN service_tier = 'GeneralPurpose' AND virtual_core_count <= 4 THEN CONCAT(virtual_core_count *3, ' MB/s')
-    WHEN service_tier = 'BusinessCritical' AND virtual_core_count <= 48/4 THEN CONCAT(virtual_core_count *4, ' MB/s')
-    ELSE '48 MB/s'
+    WHEN service_tier = 'GeneralPurpose' and mf.[Next-Gen General Purpose] = 'false' THEN CONCAT(LEAST(4.5 * virtual_core_count, 120), ' MB/s')
+    ELSE CONCAT(LEAST(4.5 * virtual_core_count, 192), ' MB/s')
     END,
     [Data rate] = 
     CASE 
-    WHEN service_tier = 'GeneralPurpose' THEN '100-250 MB/s/file'
-    ELSE CONCAT(24 * virtual_core_count, ' MB/s')
+    WHEN service_tier = 'GeneralPurpose' and mf.[Next-Gen General Purpose] = 'false' THEN '100-250 MB/s/file'
+    WHEN service_tier = 'GeneralPurpose' and mf.[Next-Gen General Purpose] = 'true' THEN 'IOPS / 30 MBps included free of charge'
+    ELSE 'Up to VM limits'
     END,
     [IOPS] = 
     CASE 
-    WHEN service_tier = 'GeneralPurpose' THEN '500-7500/file'
-    ELSE CONCAT(' ',1375 * virtual_core_count)
+    WHEN service_tier = 'GeneralPurpose' and mf.[Next-Gen General Purpose] = 'false' THEN '500-7500/file'
+    WHEN service_tier = 'GeneralPurpose' and mf.[Next-Gen General Purpose] = 'true' THEN '3 IOPS per GB of storage included free of charge'
+    ELSE CONCAT(' ', LEAST(4000* virtual_core_count, 320000))
     END,
     [Max tempdb size] = 
     CASE 
@@ -32,7 +38,16 @@ select
     END
 FROM sys.dm_os_sys_info
 
-	, (select top 1 service_tier = sku, virtual_core_count, hardware_generation, max_storage_gb = reserved_storage_mb/1024
-	from master.sys.server_resource_stats
-	where start_time > DATEADD(mi, -7, GETUTCDATE())
+    , (select top 1 service_tier = sku, virtual_core_count, hardware_generation, max_storage_gb = reserved_storage_mb/1024
+    from master.sys.server_resource_stats
+    where start_time > DATEADD(mi, -7, GETUTCDATE())
     order by start_time desc) as srs
+
+    , (select top 1
+    case
+        when physical_name like 'C:\ManagedDisks%' then 'True'
+        else 'False'
+    end as [Next-Gen General Purpose]
+    from sys.master_files
+    where database_id = 1
+    and type_desc = 'log') as mf

--- a/src/sql/properties.sql
+++ b/src/sql/properties.sql
@@ -4,8 +4,6 @@ select
     [Memory] = CASE 
     WHEN hardware_generation = 'Gen4' THEN CONCAT(7 * virtual_core_count, ' GB')
     WHEN hardware_generation = 'Gen5' THEN CONCAT(5.1 * virtual_core_count, ' GB')
-    WHEN hardware_generation = 'Gen6' THEN CONCAT(5.1 * virtual_core_count, ' GB')
-    WHEN hardware_generation = 'Gen7' THEN CONCAT(5.1 * virtual_core_count, ' GB')
     WHEN hardware_generation = 'Gen8IM' THEN CONCAT(LEAST(7 * virtual_core_count, 560), ' GB')
     WHEN hardware_generation = 'Gen8IH' THEN CONCAT(LEAST(13.6 * virtual_core_count, 870.4), ' GB')
     ELSE CONCAT(5.1 * virtual_core_count, ' GB')

--- a/src/sql/storage-usage-azure.sql
+++ b/src/sql/storage-usage-azure.sql
@@ -1,16 +1,14 @@
 IF( SERVERPROPERTY('EngineEdition') = 8 )
-WITH allocated ([Remaining files])
+WITH gp_stats ([Remaining GP files])
 AS (
 SELECT  --[Allocated TB] = CONCAT(CAST(size_tb as [tinyint]), 'TB out of 35TB'),
-		[Remaining files] = CAST((35 - size_tb) * 8 AS int)
+		[Remaining GP files] = CAST((35 - size_tb) * 8 AS int)
 FROM
 ( SELECT
         SUM(CASE
                 WHEN  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  <= 128
                     THEN 128
-                WHEN  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  > 128 AND  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  <= 256
-                    THEN 256
-                WHEN  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  > 256 AND  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  <= 512
+                WHEN  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  > 128 AND  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  <= 512
                     THEN 512
                 WHEN  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  > 512 AND  CAST(size * 8. / 1024 / 1024 AS decimal(12,4))  <= 1024
                     THEN 1024
@@ -23,30 +21,56 @@ FROM
     FROM master.sys.master_files
     WHERE physical_name LIKE 'https:%'
 ) AS alloc(size_tb)),
+next_gen_gp_stats ([Remaining Next-Gen files])
+AS (
+SELECT
+		[Remaining Next-Gen files] = CAST((32768 - file_count) AS int)
+FROM
+( SELECT COUNT(*)
+    FROM master.sys.master_files
+    WHERE physical_name LIKE 'C:\ManagedDisks%'
+) AS alloc(file_count)),
 volumes as (
-SELECT	Storage = CASE WHEN volume_mount_point = 'http://' THEN 'Remote storage'
-                        ELSE 'Local SSD'
-                    END,
+SELECT	Storage = CASE
+                    WHEN f.physical_name LIKE 'C:\ManagedDisks%' THEN 'Premium Managed Disks'
+                    WHEN f.physical_name LIKE 'https%' THEN 'Premium Page Blobs'
+                    ELSE 'Local SSD'
+                  END,
 		[GB Used] = CAST(MIN(total_bytes / 1024. / 1024 / 1024) AS NUMERIC(8,1)),
 		[GB Available] = CAST(MIN(available_bytes / 1024. / 1024 / 1024) AS NUMERIC(8,1)),
 		[GB Total] = CAST(MIN((total_bytes+available_bytes) / 1024. / 1024 / 1024) AS NUMERIC(8,1))
 FROM sys.master_files AS f
 CROSS APPLY sys.dm_os_volume_stats(f.database_id, f.file_id)
-GROUP BY volume_mount_point)
+GROUP by
+    CASE
+        WHEN f.physical_name LIKE 'C:\ManagedDisks%' THEN 'Premium Managed Disks'
+        WHEN f.physical_name LIKE 'https%' THEN 'Premium Page Blobs'
+        ELSE 'Local SSD'
+    END)
 SELECT  [ ] = 'User/system databases',
         [GB Used], [GB Available], [GB Total], 
-        [Remaining files (data and log)] = [Remaining files],
+        [Remaining files (data and log)] = [Remaining GP files],
         [*Backups are not included in this report] = ''
 FROM volumes
-    join allocated
-        on volumes.Storage = 'Remote storage'
-WHERE volumes.Storage = 'Remote storage'
+    join gp_stats
+        on volumes.Storage = 'Premium Page Blobs'
+WHERE volumes.Storage = 'Premium Page Blobs'
+UNION ALL
+SELECT [ ] = 'User/system databases',
+        [GB Used], [GB Available], [GB Total],
+        [Remaining files (data and log)] = [Remaining Next-Gen files],
+        [*Backups are not included in this report] = ''
+FROM volumes
+    JOIN next_gen_gp_stats
+        ON volumes.Storage = 'Premium Managed Disks'
+WHERE volumes.Storage = 'Premium Managed Disks'
 UNION ALL
 SELECT [ ] = 'Not available', 
         [GB Used] = 0, [GB Available] = 0, [GB Total] = 0, 
         [Remaining files (data and log)] = 0,
         [*Backups are not included in this report] = ''
 FROM volumes
-    join allocated
-        on volumes.Storage <> 'Remote storage'
+    join gp_stats
+        on volumes.Storage = 'Local SSD'
+WHERE volumes.Storage = 'Local SSD'
 ;


### PR DESCRIPTION
This change introduces support for Next-Gen General Purpose edition in ADS extension for SQL MI. 

Beside this, some service limitations have been changed in the past (new hardware generations were introduced, log rate limits were increased), so in this PR I aligned the extension with the actual limits:

- Gen8IM and Gen8IH are new HW generations with different memory limitations
- Next-Gen GP filed is introduced (values true/false), which should distinguish between classic GP and Next-Gen GP
- Log rate numbers were from 2019., aligned them with the current limits (4.5 x vCore with 192MBps max, or 120MBps max for GP)
- Instead of per file IOPS/Throughput for Next-Gen GP, actual calculation for free of charge IOPS/Throuhput is displayed
- Renamed Azure Premium Disks storage to Azure Remote Storage as classic GP is using page blobs, Next-Gen is using managed disks 
- Aligned all limits for Next-Gen GP 